### PR TITLE
Remove Capybara and Nokogiri from the dependencies

### DIFF
--- a/lib/lookout/rack/test/version.rb
+++ b/lib/lookout/rack/test/version.rb
@@ -1,7 +1,7 @@
 module Lookout
   module Rack
     module Test
-      VERSION = "2.1.0"
+      VERSION = "2.2.0"
     end
   end
 end

--- a/lookout-rack-test.gemspec
+++ b/lookout-rack-test.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ci_reporter'
   spec.add_dependency 'ci_reporter_cucumber'
   spec.add_dependency 'ci_reporter_rspec'
-  spec.add_dependency 'nokogiri'
   spec.add_dependency 'rack-test'
   # For freezing time inside of tests
   spec.add_dependency 'timecop'
@@ -36,6 +35,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'factory_girl'
   spec.add_dependency 'cucumber'
   spec.add_dependency 'parallel_tests'
-
-  spec.add_dependency 'capybara', '~> 2.2'
 end


### PR DESCRIPTION
This gem does not configure these dependencies in any way. Since we don't use Capybara for testing in our project, this was adding unnecessary dependencies.

@ismith 