### PR TITLE
Remove parallel_tests, since it's useless for JRuby

### DIFF
--- a/lib/lookout/rack/test/rake/cucumber.rake
+++ b/lib/lookout/rack/test/rake/cucumber.rake
@@ -1,11 +1,6 @@
 require 'cucumber/rake/task'
 require 'ci/reporter/rake/cucumber'
 
-# parallel_tests is somewhat pointless/nonfunctional on JRuby
-unless RUBY_PLATFORM == 'java'
-  require 'parallel_tests/tasks'
-end
-
 namespace :cucumber do
   Cucumber::Rake::Task.new(:api) do |t|
     t.cucumber_opts = '--profile api'

--- a/lib/lookout/rack/test/version.rb
+++ b/lib/lookout/rack/test/version.rb
@@ -1,7 +1,7 @@
 module Lookout
   module Rack
     module Test
-      VERSION = "2.3.1"
+      VERSION = "2.4.0"
     end
   end
 end

--- a/lookout-rack-test.gemspec
+++ b/lookout-rack-test.gemspec
@@ -34,5 +34,4 @@ Gem::Specification.new do |spec|
   # Used to assist with scaffolded data and generating random data
   spec.add_dependency 'factory_girl'
   spec.add_dependency 'cucumber'
-  spec.add_dependency 'parallel_tests'
 end


### PR DESCRIPTION
Pulling this in just doesn't buy us anything