### PR TITLE
Remove dependency on ci_reporter base

### DIFF
--- a/lib/lookout/rack/test/version.rb
+++ b/lib/lookout/rack/test/version.rb
@@ -1,7 +1,7 @@
 module Lookout
   module Rack
     module Test
-      VERSION = "3.0.0"
+      VERSION = "3.1.0"
     end
   end
 end

--- a/lookout-rack-test.gemspec
+++ b/lookout-rack-test.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   # Required for {{token}} substitutions in Cucumber API scenarios
   spec.add_dependency 'liquid'
   spec.add_dependency 'rspec'
-  spec.add_dependency 'ci_reporter'
   spec.add_dependency 'ci_reporter_cucumber'
   spec.add_dependency 'ci_reporter_rspec'
   spec.add_dependency 'rack-test'


### PR DESCRIPTION
From the ci_reporter README:

    To upgrade to 2.x, remove ci_reporter from your Gemfile and replace
    it with one or more of the framework-specific gems above.

This already depended upon ci_reporter_rspec and ci_reporter_cucumber.